### PR TITLE
Allow airbrake to ignore exceptions

### DIFF
--- a/lib/delayed-plugins-airbrake.rb
+++ b/lib/delayed-plugins-airbrake.rb
@@ -13,9 +13,7 @@ module Delayed::Plugins::Airbrake
           :error_message => "#{exception.class.name}: #{exception.message}",
           :backtrace     => exception.backtrace,
           :component     => 'DelayedJob Worker',
-          :parameters    => {
-            :failed_job => job.inspect
-          }
+          :parameters    => job.attributes
         )
         super if defined?(super)
       end


### PR DESCRIPTION
Heya - how about using `notify_or_ignore` instead of `notify`, so that exceptions in Airbrake's ignore-list don't get reported?