### PR TITLE
Fix: Config. to ignore some exceptions was ignored.

### DIFF
--- a/lib/delayed-plugins-airbrake.rb
+++ b/lib/delayed-plugins-airbrake.rb
@@ -8,7 +8,7 @@ module Delayed::Plugins::Airbrake
   class Plugin < ::Delayed::Plugin
     module Notify
       def error(job, exception)
-        ::Airbrake.notify(exception,
+        ::Airbrake.notify_or_ignore(exception,
           :error_class   => exception.class.name,
           :error_message => "#{exception.class.name}: #{exception.message}",
           :backtrace     => exception.backtrace,


### PR DESCRIPTION
The Airbrake method to call should be notify_or_ignore() rather than notify().
The first performs some checks against the user's configuration to see if
the current exception is meant to be notified.